### PR TITLE
Fix triggering onStopped and onEnded when restarting a stopped timer

### DIFF
--- a/lib/stop_watch_timer.dart
+++ b/lib/stop_watch_timer.dart
@@ -345,7 +345,7 @@ class StopWatchTimer {
       _timer!.cancel();
       _timer = null;
     }
-    if (isRunning || _startTime > 0) {
+    if (isRunning && _startTime > 0) {
       _onStoppedController.add(true);
       if (onStopped != null) {
         onStopped!();


### PR DESCRIPTION
Calling `onResetTimer` on a stopped timer triggers `onStop` and `onEnded` events. I expect these event not to trigger if the timer is not running.

Consider this use case. I want to create a countdown timer that restarts from the beginning every 5 seconds:

```dart
class MyApp extends StatefulWidget {
  @override
  _MyAppState createState() => _MyAppState();
}

class _MyAppState extends State<MyApp> {

  final StopWatchTimer _stopWatchTimer = StopWatchTimer(
    mode: StopWatchMode.countDown,
    presetMillisecond: 5000,
  );

  @override
  void initState() {
    super.initState();
    _stopWatchTimer.fetchEnded.listen((v) {
      print('Ended, value: $v');
      _stopWatchTimer.onResetTimer();
      _stopWatchTimer.onStartTimer();
    });
    _stopWatchTimer.onStartTimer();
  }

  @override
  void dispose() async {
    super.dispose();
    await _stopWatchTimer.dispose();
  }

  @override
  Widget build(BuildContext context) {
    return Container();
  }
}
```

I expect this code to work, but every time in calls `onResetTimer` it also triggers `fetchEnded`, so it enters an infinite loop.

This fix replaces `isRunning || _startTime > 0` with `isRunning && _startTime > 0`, so now resetting a stopped container doesn't trigger these events. 