### PR TITLE
Fixing crashing bug with reset callback after closed

### DIFF
--- a/lib/stop_watch_timer.dart
+++ b/lib/stop_watch_timer.dart
@@ -403,8 +403,12 @@ class StopWatchTimer {
     _currentSessionStartTime = 0;
     _previousTotalSessionTime = 0;
     _records = [];
-    _recordsController.add(_records);
-    _elapsedTime.add(_presetTime);
+    if (!_recordsController.isClosed) {
+      _recordsController.add(_records);
+    }
+    if (!_elapsedTime.isClosed) {
+      _elapsedTime.add(_presetTime);
+    }
   }
 
   void _lap() {


### PR DESCRIPTION
There's a scenario with this plugin's use inside flutterflow where if you have a stop / reset command callback on timer end, and the widget has disposed already before the callback a main thread crash occurs with the following trace:

broadcast_stream_controller.dart - Line 243
BroadcastStreamController.add (#3) + 243

subject.dart - Line 151
Subject._add + 151

subject.dart - Line 141
Subject.add (#3) + 141

stop_watch_timer.dart - Line 406
StopWatchTimer._reset + 406

stop_watch_timer.dart - Line 270
FlutterFlowTimerController.onResetTimer + 270