### PR TITLE
fix: Check stream is not closed before adding more events

### DIFF
--- a/lib/stop_watch_timer.dart
+++ b/lib/stop_watch_timer.dart
@@ -340,6 +340,10 @@ class StopWatchTimer {
   }
 
   void _handle(Timer timer) {
+    if (_elapsedTime.isClosed) {
+      return;
+    }
+
     switch (mode) {
       case StopWatchMode.countUp:
         _elapsedTime.add(_getCountUpTime());


### PR DESCRIPTION
Check that the stream is not closed before adding more events

` Fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError: Bad state: Cannot add new events after calling close
       at _BroadcastStreamController.add(dart:async)
       at Subject._add(subject.dart:151)
       at Subject.add(subject.dart:141)
       at StopWatchTimer._handle(stop_watch_timer.dart:345)
        `